### PR TITLE
Implement health entry screen and lint/test setup

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: 'universe/native',
+};

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
 # BPC-Pulse
+
+BPC-Pulse is a simple application built with Expo and React Native. It allows athletes to quickly record their morning health metrics so they can monitor trends over time.
+
+## Installation
+
+```bash
+npm install
+```
+
+## Development
+
+Run the app in development mode with Expo:
+
+```bash
+npm run dev
+```
+
+## Purpose of Morning Entry
+
+On the home screen, athletes enter their resting heart rate, how well they slept, and how they feel when they wake up. These values are stored on the device so you can review your data even when offline.
+
+## Dependencies
+
+Key dependencies used in this project include:
+
+- **Expo** – framework for running the app
+- **Expo Router** – file based routing
+- **React Native** – UI components
+- **@react-native-async-storage/async-storage** – local data persistence
+- **expo-haptics** and **@expo/vector-icons** – enhance the user interface
+
+## Linting and Testing
+
+The project uses ESLint (`npm run lint`) and Jest (`npm test`) to keep code reliable.

--- a/__tests__/index.test.tsx
+++ b/__tests__/index.test.tsx
@@ -1,0 +1,9 @@
+import { render } from '@testing-library/react-native';
+import Index from '../app/index';
+
+describe('Index screen', () => {
+  it('renders heading', () => {
+    const { getByText } = render(<Index />);
+    expect(getByText('Morning Check-In')).toBeTruthy();
+  });
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function Layout() {
+  return <Stack />;
+}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet, Alert } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import * as Haptics from 'expo-haptics';
+import { saveMetrics, getMetrics, MetricsData } from '../storage/morningMetrics';
+
+export default function Index() {
+  const [heartRate, setHeartRate] = useState('');
+  const [sleepQuality, setSleepQuality] = useState('');
+  const [wellness, setWellness] = useState('');
+
+  useEffect(() => {
+    async function load() {
+      const metrics = await getMetrics();
+      if (metrics) {
+        setHeartRate(String(metrics.heartRate));
+        setSleepQuality(String(metrics.sleepQuality));
+        setWellness(String(metrics.wellness));
+      }
+    }
+    load();
+  }, []);
+
+  const validate = (): MetricsData | null => {
+    const hr = Number(heartRate);
+    const sq = Number(sleepQuality);
+    const wel = Number(wellness);
+    if (
+      isNaN(hr) || hr < 30 || hr > 220 ||
+      isNaN(sq) || sq < 1 || sq > 10 ||
+      isNaN(wel) || wel < 1 || wel > 5
+    ) {
+      Alert.alert('Invalid input', 'Please enter valid numbers.');
+      return null;
+    }
+    return { heartRate: hr, sleepQuality: sq, wellness: wel };
+  };
+
+  const save = async () => {
+    const data = validate();
+    if (data) {
+      await saveMetrics(data);
+      await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+      Alert.alert('Saved', 'Your metrics have been saved.');
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Morning Check-In</Text>
+      <View style={styles.inputRow}>
+        <Ionicons name="heart" size={24} />
+        <TextInput
+          style={styles.input}
+          placeholder="Heart Rate"
+          keyboardType="numeric"
+          value={heartRate}
+          onChangeText={setHeartRate}
+        />
+      </View>
+      <View style={styles.inputRow}>
+        <Ionicons name="bed" size={24} />
+        <TextInput
+          style={styles.input}
+          placeholder="Sleep Quality (1-10)"
+          keyboardType="numeric"
+          value={sleepQuality}
+          onChangeText={setSleepQuality}
+        />
+      </View>
+      <View style={styles.inputRow}>
+        <Ionicons name="happy" size={24} />
+        <TextInput
+          style={styles.input}
+          placeholder="Wellness (1-5)"
+          keyboardType="numeric"
+          value={wellness}
+          onChangeText={setWellness}
+        />
+      </View>
+      <Button title="Save" onPress={save} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 20, justifyContent: 'center', gap: 10 },
+  title: { fontSize: 24, fontWeight: 'bold', marginBottom: 20, textAlign: 'center' },
+  inputRow: { flexDirection: 'row', alignItems: 'center', gap: 10 },
+  input: { flex: 1, borderWidth: 1, borderColor: '#ccc', padding: 8, borderRadius: 4 },
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'jest-expo',
+  setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect'],
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "EXPO_NO_TELEMETRY=1 expo start",
     "build:web": "expo export --platform web",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "test": "jest"
   },
   "dependencies": {
     "@expo-google-fonts/inter": "^0.2.3",
@@ -45,6 +46,14 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "eslint": "^8.57.0",
+    "eslint-config-universe": "^12.2.0",
+    "jest": "^29.7.0",
+    "jest-expo": "^48.0.2",
+    "@testing-library/react-native": "^12.0.0",
+    "@testing-library/jest-native": "^5.4.2",
+    "react-test-renderer": "19.0.0",
+    "@types/jest": "^29.5.8"
   }
 }

--- a/storage/morningMetrics.ts
+++ b/storage/morningMetrics.ts
@@ -1,0 +1,25 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export type MetricsData = {
+  heartRate: number;
+  sleepQuality: number;
+  wellness: number;
+};
+
+const PREFIX = 'metrics:';
+const ONE_DAY = 24 * 60 * 60 * 1000;
+
+function formatDate(date: Date) {
+  return date.toISOString().split('T')[0];
+}
+
+export async function saveMetrics(data: MetricsData, date = new Date()): Promise<void> {
+  const key = PREFIX + formatDate(date);
+  await AsyncStorage.setItem(key, JSON.stringify(data));
+}
+
+export async function getMetrics(date = new Date(Date.now() - ONE_DAY)): Promise<MetricsData | null> {
+  const key = PREFIX + formatDate(date);
+  const json = await AsyncStorage.getItem(key);
+  return json ? (JSON.parse(json) as MetricsData) : null;
+}


### PR DESCRIPTION
## Summary
- flesh out README with setup instructions
- set up ESLint and Jest configs
- add morning check-in screen via Expo Router
- persist metrics with AsyncStorage
- provide a simple unit test for the screen

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414b7bd04c832ba411c123183a4e62